### PR TITLE
refactor(vm): use `HandleId` instead of `usize`

### DIFF
--- a/crates/v8_vm/src/frame.rs
+++ b/crates/v8_vm/src/frame.rs
@@ -1,5 +1,6 @@
 //! Frame for the V8-Rust VM
 
+use crate::heap::HandleId;
 use crate::value::Value;
 use std::collections::HashMap;
 
@@ -11,7 +12,7 @@ pub struct Frame {
     pub base_pointer: usize,
     pub arguments: Vec<Value>,
     pub closure_vars: HashMap<String, Value>,
-    pub function_handle: Option<usize>, // Handle da função atual (para recursão)
+    pub function_handle: Option<HandleId>,
     pub this_value: Option<Value>, // Valor de this da função atual
 }
 

--- a/crates/v8_vm/src/heap.rs
+++ b/crates/v8_vm/src/heap.rs
@@ -1,8 +1,39 @@
 //! Heap for the V8-Rust VM
 
-use std::collections::HashMap;
-use crate::value::Value;
 use crate::bytecode::Bytecode;
+use crate::value::Value;
+use std::collections::HashMap;
+use std::ops::Deref;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct HandleId(usize);
+
+impl From<usize> for HandleId {
+    fn from(value: usize) -> Self {
+        HandleId(value)
+    }
+}
+
+impl From<&usize> for HandleId {
+    fn from(value: &usize) -> Self {
+        HandleId(*value)
+    }
+}
+
+impl Deref for HandleId {
+    type Target = usize;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl PartialEq<usize> for HandleId {
+    fn eq(&self, other: &usize) -> bool {
+        self.0 == *other
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum HeapEntry {
@@ -26,70 +57,83 @@ impl Heap {
     pub fn new() -> Self {
         Heap { entries: Vec::new() }
     }
-    pub fn alloc_object(&mut self) -> usize {
+    pub fn alloc_entry(&mut self, entry: HeapEntry) -> HandleId {
         let idx = self.entries.len();
-        self.entries.push(HeapEntry::Object(HashMap::new()));
-        idx
+        self.entries.push(entry);
+        HandleId(idx)
     }
-    pub fn alloc_array(&mut self) -> usize {
-        let idx = self.entries.len();
-        self.entries.push(HeapEntry::Array(Vec::new()));
-        idx
+    pub fn alloc_object(&mut self) -> HandleId {
+        self.alloc_entry(HeapEntry::Object(HashMap::new()))
     }
-    pub fn alloc_function(&mut self, bytecode: Bytecode, arg_count: usize, local_count: usize) -> usize {
-        let idx = self.entries.len();
-        self.entries.push(HeapEntry::Function {
+    pub fn alloc_array(&mut self) -> HandleId {
+        self.alloc_entry(HeapEntry::Array(Vec::new()))
+    }
+    pub fn alloc_function(
+        &mut self,
+        bytecode: Bytecode,
+        arg_count: usize,
+        local_count: usize,
+    ) -> HandleId {
+        self.alloc_entry(HeapEntry::Function {
             bytecode,
             arg_count,
             local_count,
             closure_vars: HashMap::new(),
-        });
-        idx
+        })
     }
-    pub fn get_function_info(&self, handle: usize) -> Option<(&Bytecode, &usize, &usize, &HashMap<String, Value>)> {
-        if let Some(HeapEntry::Function { bytecode, arg_count, local_count, closure_vars }) = self.entries.get(handle) {
+    pub fn get_function_info(
+        &self,
+        handle: HandleId,
+    ) -> Option<(&Bytecode, &usize, &usize, &HashMap<String, Value>)> {
+        if let Some(HeapEntry::Function {
+            bytecode,
+            arg_count,
+            local_count,
+            closure_vars,
+        }) = self.get(handle)
+        {
             Some((bytecode, arg_count, local_count, closure_vars))
         } else {
             None
         }
     }
-    pub fn set_closure_var(&mut self, handle: usize, name: String, value: Value) {
-        if let Some(HeapEntry::Function { closure_vars, .. }) = self.entries.get_mut(handle) {
+    pub fn set_closure_var(&mut self, handle: HandleId, name: String, value: Value) {
+        if let Some(HeapEntry::Function { closure_vars, .. }) = self.entries.get_mut(*handle) {
             closure_vars.insert(name, value);
         }
     }
-    pub fn get(&self, handle: usize) -> Option<&HeapEntry> {
-        self.entries.get(handle)
+    pub fn get(&self, handle: HandleId) -> Option<&HeapEntry> {
+        self.entries.get(*handle)
     }
-    pub fn get_mut(&mut self, handle: usize) -> Option<&mut HeapEntry> {
-        self.entries.get_mut(handle)
+    pub fn get_mut(&mut self, handle: HandleId) -> Option<&mut HeapEntry> {
+        self.entries.get_mut(*handle)
     }
-    pub fn set_object_property(&mut self, handle: usize, key: String, value: Value) {
-        if let Some(HeapEntry::Object(obj)) = self.entries.get_mut(handle) {
+    pub fn set_object_property(&mut self, handle: HandleId, key: String, value: Value) {
+        if let Some(HeapEntry::Object(obj)) = self.get_mut(handle) {
             obj.insert(key, value);
         }
     }
-    pub fn get_object_property(&self, handle: usize, key: &str) -> Option<&Value> {
-        if let Some(HeapEntry::Object(obj)) = self.entries.get(handle) {
+    pub fn get_object_property(&self, handle: HandleId, key: &str) -> Option<&Value> {
+        if let Some(HeapEntry::Object(obj)) = self.get(handle) {
             obj.get(key)
         } else {
             None
         }
     }
-    pub fn push_array_element(&mut self, handle: usize, value: Value) {
-        if let Some(HeapEntry::Array(arr)) = self.entries.get_mut(handle) {
+    pub fn push_array_element(&mut self, handle: HandleId, value: Value) {
+        if let Some(HeapEntry::Array(arr)) = self.get_mut(handle) {
             arr.push(value);
         }
     }
-    pub fn get_array_element(&self, handle: usize, idx: usize) -> Option<&Value> {
-        if let Some(HeapEntry::Array(arr)) = self.entries.get(handle) {
+    pub fn get_array_element(&self, handle: HandleId, idx: usize) -> Option<&Value> {
+        if let Some(HeapEntry::Array(arr)) = self.get(handle) {
             arr.get(idx)
         } else {
             None
         }
     }
-    pub fn set_array_element(&mut self, handle: usize, idx: usize, value: Value) {
-        if let Some(HeapEntry::Array(arr)) = self.entries.get_mut(handle) {
+    pub fn set_array_element(&mut self, handle: HandleId, idx: usize, value: Value) {
+        if let Some(HeapEntry::Array(arr)) = self.get_mut(handle) {
             if idx < arr.len() {
                 arr[idx] = value;
             } else {
@@ -99,13 +143,13 @@ impl Heap {
             }
         }
     }
-    pub fn remove_object_property(&mut self, handle: usize, key: &str) {
-        if let Some(HeapEntry::Object(obj)) = self.entries.get_mut(handle) {
+    pub fn remove_object_property(&mut self, handle: HandleId, key: &str) {
+        if let Some(HeapEntry::Object(obj)) = self.get_mut(handle) {
             obj.remove(key);
         }
     }
-    pub fn has_object_property(&self, handle: usize, key: &str) -> bool {
-        if let Some(HeapEntry::Object(obj)) = self.entries.get(handle) {
+    pub fn has_object_property(&self, handle: HandleId, key: &str) -> bool {
+        if let Some(HeapEntry::Object(obj)) = self.get(handle) {
             obj.contains_key(key)
         } else {
             false

--- a/crates/v8_vm/src/value.rs
+++ b/crates/v8_vm/src/value.rs
@@ -1,13 +1,15 @@
 //! Value type for the V8-Rust VM
 
+use crate::heap::HandleId;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Number(f64),
     String(String),
     Boolean(bool),
-    Object(usize), // handle para o heap
-    Array(usize),  // handle para o heap
-    Function(usize), // handle para o heap
+    Object(HandleId),
+    Array(HandleId),
+    Function(HandleId),
     Null,
     Undefined,
 }

--- a/crates/v8_vm/tests/function_closure_tests.rs
+++ b/crates/v8_vm/tests/function_closure_tests.rs
@@ -40,7 +40,7 @@ fn test_closure_variables() {
 
 #[test]
 fn test_function_value_creation() {
-    let func_value = Value::Function(0); // handle 0
+    let func_value = Value::Function(HandleId::from(0));
     assert!(!func_value.is_primitive());
     assert_eq!(func_value.to_string(), "[function]");
     assert!(func_value.to_boolean()); // funções são truthy
@@ -156,8 +156,8 @@ fn test_load_this_function() {
     exec.heap = heap;
     
     println!("=== Teste LoadThisFunction ===");
-    println!("Func handle: {}", func_handle);
-    
+    println!("Func handle: {:?}", func_handle);
+
     // Criar um objeto para ser usado como this
     let obj_handle = exec.heap.alloc_object();
     let this_obj = Value::Object(obj_handle);


### PR DESCRIPTION
close #12 

I need to let you know that `main` branch cannot compile, I made some local fixes and that is not friendly to external contributors. Also, there are a lot of unformatted code, and some of them can be skipped with `#[rustfmt::skip]`.

About this PR I tried to do my best for minimal changes. I will follow the project to contribute.